### PR TITLE
adding requirements.txt and adding CLI argument to specify run_mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,15 @@
-from SnakeEnvironment import SnakeEnv
 import time
 import numpy as np
 import random
+import sys
+from SnakeEnvironment import SnakeEnv
+from DeepNeuralNetworkDriver import DnnDriver
 from statistics import mean
 from collections import Counter
 from tqdm import tqdm
 from datetime import datetime
-from DeepNeuralNetworkDriver import DnnDriver
+
+
 start_time = time.time()
 random.seed(time.time())
 now = datetime.now()  # current date and time
@@ -16,7 +19,7 @@ run_dir = now.strftime("%Y_%m_%d___%H_%M_%S")
 # 1:  Train a new model
 # 2:  Load the last model
 # 3:  Load a specific model
-run_mode = 1
+run_mode = int(sys.argv[1])
 profile_run = False
 
 run_to_load = '2022_11_19___00_45_36'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+gym==0.26.2
+numpy==1.23.1
+pygame==2.1.2
+tensorflow==2.11.0
+tflearn==0.5.0
+tqdm==4.64.1


### PR DESCRIPTION
also fixed ordering of imports in ./main.py

`adding CLI argument to specify run_mode`
So, instead of setting the variable in between runs, can just specify `python3 main.py {0,1,2,3}`